### PR TITLE
Tighten up edge case handling

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -86,15 +86,15 @@ that are defined in the same local scope as an `@stubby`-annotated object/type.
 If you ever annotate an object/type that extends a type from its local scope
 with `@stubby`, you'll get a compile-time error. For example:
 ```scala
-scala> import org.scala_stubby.stubby
-import org.scala_stubby.stubby
+scala> import org.scala_stubby._
+import org.scala_stubby._
 
 scala> def foo = {
      |   class C
      |   @stubby class D extends C
      |   new D
      | }
-<console>:14: error: Stubby cannot see the signature for C. Perhaps it's defined as a local class/trait.
+<console>:16: warning: Stubby cannot see C. Perhaps it's defined as a local class/trait.
          @stubby class D extends C
                                  ^
 ```

--- a/src/test/scala/stubbyTests.scala
+++ b/src/test/scala/stubbyTests.scala
@@ -16,8 +16,9 @@
 package org.scala_stubby
 
 import org.scalatest.FunSuite
+import reflect.{ClassTag, classTag}
 
-abstract class BaseClass {
+abstract class SimpleBase {
   def test(a: Int, b: Int): String = test
   val test: String
   def foo(s: String): String = s
@@ -26,6 +27,26 @@ abstract class BaseClass {
 trait AccessTestBase {
   private[scala_stubby] def foo: String
   protected val bar: Int
+}
+
+abstract class ClassParamBase(param: Int) {
+  def test = param
+}
+
+abstract class AccessibleClassParamBase(val param: Int) {
+  def test = param
+}
+
+abstract class ImplicitParamBase[T](implicit c: ClassTag[T]) {
+  def test(a: Int, b: Int): String = test
+  val test: String
+  def foo(s: String): String = s
+}
+
+abstract class CtxBoundBase[T: ClassTag] {
+  def test(a: Int, b: Int): String = test
+  val test: String
+  def foo(s: String): String = s
 }
 
 @stubby class AccessTest extends AccessTestBase
@@ -114,7 +135,7 @@ class stubbyTests extends FunSuite {
 
   test("stubs inherited members") {
 
-    @stubby object Test extends BaseClass {
+    @stubby object Test extends SimpleBase {
       def bar(s: String): String = s
     }
 
@@ -136,10 +157,76 @@ class stubbyTests extends FunSuite {
   }
 
   test("allows implementing abstract members from the parent") {
-    @stubby class Test extends BaseClass {
+    @stubby class Test extends SimpleBase {
       val test = "3"
     }
     (new Test).test(1,2)
+  }
+
+  test("supports parameters on the base class") {
+    @stubby class Test extends ClassParamBase(3) {
+      def foo: String
+    }
+    intercept[NotImplementedError] {
+      (new Test).foo
+    }
+    (new Test).test
+  }
+
+  test("supports accessible parameters on the base class") {
+    @stubby class Test extends AccessibleClassParamBase(2) {
+      def foo: String
+    }
+    intercept[NotImplementedError] {
+      (new Test).foo
+    }
+    (new Test).test
+    (new Test).param
+  }
+
+  test("supports implicit parameter lists on members") {
+    @stubby class Test extends SimpleBase {
+      def foo[T](implicit ct: ClassTag[T]): String
+      def bar[T](implicit ct: ClassTag[T]) = classTag[T]
+    }
+    intercept[NotImplementedError] {
+      (new Test).foo[String]
+    }
+    (new Test).bar[String]
+  }
+
+  test("supports implicit parameter lists on base") {
+    @stubby class Test extends ImplicitParamBase[String] {
+      def foo[T](implicit ct: ClassTag[T]): String
+      def bar[T](implicit ct: ClassTag[T]) = classTag[T]
+    }
+    intercept[NotImplementedError] {
+      (new Test).foo[String]
+    }
+    (new Test).bar[String]
+  }
+
+  test("supports context bounds on members") {
+    @stubby class Test extends SimpleBase {
+      def foo[T: ClassTag]: String
+      def bar[T: ClassTag] = classTag[T]
+    }
+    intercept[NotImplementedError] {
+      (new Test).foo[String]
+    }
+    (new Test).bar[String]
+  }
+
+
+  test("supports context bounds on base") {
+    @stubby class Test extends CtxBoundBase[String] {
+      def foo[T: ClassTag]: String
+      def bar[T: ClassTag] = classTag[T]
+    }
+    intercept[NotImplementedError] {
+      (new Test).foo[String]
+    }
+    (new Test).bar[String]
   }
 
 }


### PR DESCRIPTION
* Support implicit parameters / context bounds
* Issue a warning instead an error when Stubby can't see a base type
* Fail more gracefully when the user misses a parent constructor arg